### PR TITLE
Remove mustache oriented data from `data.json`

### DIFF
--- a/dist/_data/data.json
+++ b/dist/_data/data.json
@@ -77,17 +77,5 @@
 		"last-name": "Name"
 	},
 	"hero": true,
-	"emergency" : false,
-	"touts" : [
-		{ },
-		{ },
-		{ }
-	],
-	"latest-posts" : [
-		{ },
-		{ },
-		{ },
-		{ },
-		{ }
-	]
+	"emergency" : false
 }


### PR DESCRIPTION
The array with empty nodes strategy does not work in Twig the way it does with Mustache (i.e. iterate over the nodes in the array). 
A `for` loop can be used for that.
