### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "starterkit-twig-demo",
+  "version": "3.0.1",
+  "description": "Pattern Lab's Demo StarterKit for Twig.",
+  "main": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pattern-lab/starterkit-twig-demo.git"
+  },
+  "keywords": [
+    "Pattern Lab",
+    "Atomic Design",
+    "Twig",
+    "Starterkit"
+  ],
+  "author": "Dave Olsen",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/pattern-lab/starterkit-twig-demo/issues"
+  },
+  "homepage": "https://github.com/pattern-lab/starterkit-twig-demo#readme"
+}


### PR DESCRIPTION
Without package.json the starterkit cannot be installed using Yarn.